### PR TITLE
Style About Page

### DIFF
--- a/src/ckanext-hack4laatd/ckanext/hack4laatd/assets/style.css
+++ b/src/ckanext-hack4laatd/ckanext/hack4laatd/assets/style.css
@@ -164,6 +164,41 @@ body {
   border-color: var(--cyan-blue);
 }
 
+/* typography */
+h1,
+.h1 {
+  font-size: var(--font-size-h1-desktop);
+  font-weight: bold;
+}
+
+h2,
+.h2 {
+  font-size: var(--font-size-h2-desktop);
+}
+
+h3,
+.h3 {
+  font-size: var(--font-size-h3-desktop);
+}
+
+h4,
+.h4 {
+  font-size: var(--font-size-h4-desktop);
+}
+
+h5,
+.h5 {
+  font-size: var(--font-size-h5-desktop);
+}
+
+h6,
+.h6 {
+  font-size: var(--font-size-h6-desktop);
+}
+
+p {
+  font-size: var(--font-size-p2)
+}
 
 /* header */
 .masthead,
@@ -263,4 +298,20 @@ body {
     font-weight: 400;
     font-size: var(--font-size-footer-1-desktop);
   }
+}
+
+.about_page .wrapper {
+  background-color: var(--body-bg);
+  border: none;
+  box-shadow: none;
+}
+
+.about_page .about_base h1,
+.about_page .about_base h2 {
+  color: var(--cyan-blue)
+}
+
+.about_page .team_base {
+  background-color: var(--lemon-meringue);
+  color: var(--dark-blue)
 }

--- a/src/ckanext-hack4laatd/ckanext/hack4laatd/templates/home/about.html
+++ b/src/ckanext-hack4laatd/ckanext/hack4laatd/templates/home/about.html
@@ -1,0 +1,79 @@
+{% ckan_extends %}
+
+{% block content %}
+  <div class="main about_page">
+    <div id="content">
+      <div class="about_base">
+        <div class="container">
+          {% block about %}
+            <article class="module offset-md-2 col-md-8 col-xs-12 py-5" role="main">
+              <div class="row offset-md-3 col-md-6">
+                <h1 class="page-heading text-center border-bottom">
+                  {{ _('About') }}
+                </h1>
+              </div>
+              {% block about_content %}
+                {% if g.site_about %}
+                  {{ h.render_markdown(g.site_about) }}
+                {% else %}
+                  {% snippet 'home/snippets/about_text.html' %}
+                {% endif %}
+              {% endblock %}
+            </article>
+          {% endblock %}
+        </div>
+      </div>
+      <div class="team_base">
+        <div class="container py-5">
+          {% block team %}
+            <article class="module offset-md-1 col-md-10 col-xs-12 py-5">
+              <h1 class="page-heading text-center">{{ _('Meet the Team') }}</h1>
+              <p class="text-center my-5">
+                Access the Data is developed and run by a team of volunteers
+                through Hack for LA.
+              </p>
+              <div class="d-flex flex-wrap justify-content-evenly my-5">
+                <div class="text-center">
+                  <img src="/img/clp/People of Brooklyn Avatar and Background-1.png" />
+                  <br/>Person
+                </div>
+                <div class="text-center">
+                  <img src="/img/clp/People of Brooklyn Avatar and Background-2.png" />
+                  <br/>Person
+                </div>
+                <div class="text-center">
+                  <img src="/img/clp/People of Brooklyn Avatar and Background-3.png" />
+                  <br/>Person
+                </div>
+                <div class="text-center">
+                  <img src="/img/clp/People of Brooklyn Avatar and Background-4.png" />
+                  <br/>Person
+                </div>
+                <div class="text-center">
+                  <img src="/img/clp/People of Brooklyn Avatar and Background-5.png" />
+                  <br/>Person
+                </div>
+                <div class="text-center">
+                  <img src="/img/clp/People of Brooklyn Avatar and Background-6.png" />
+                  <br/>Person
+                </div>
+              </div>
+              </article>
+          {% endblock %}
+        </div>
+      </div>
+      <div class="contact_base">
+        <div class="container py-5">
+          {% block contact %}
+            <article class="module offset-md-2 col-md-8 col-xs-12 py-5">
+              <h1 class="page-heading text-center">{{ _('Contact') }}</h1>
+              <p class="text-center my-5">
+                To come.
+              </p>
+            </article>
+          {% endblock %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/src/ckanext-hack4laatd/ckanext/hack4laatd/templates/home/snippets/about_text.html
+++ b/src/ckanext-hack4laatd/ckanext/hack4laatd/templates/home/snippets/about_text.html
@@ -1,0 +1,16 @@
+<h2 class="page-heading text-center my-4">{{ _('Why We Built Access the Data') }}</h2>
+{% trans %}
+    <p>LA County government organizations rely on data and data analysis to craft
+    policies. Much of this data is made public. That means community members could
+    access it, analyze it, and use it to advocate for their communities.</p>
+
+    <p>The problem is that LA County government data can be hard to find.</p>
+
+    <p>We’re on a mission to change that.</p>
+
+    <p>We’re building Access the Data – a one-stop search tool where community
+    members can find available LA county government data.</p>
+
+    <p>Our goal is to empower more community members to engage in data-driven
+    community advocacy.
+{% endtrans %}


### PR DESCRIPTION
- Styles the about page according to design, without the contact form (separate issue in #12).
- snippet for about text, which can be overridden by CKAN's default config.